### PR TITLE
removed background-script from manifest that was intended for chrome …

### DIFF
--- a/js/content-script.js
+++ b/js/content-script.js
@@ -17,7 +17,7 @@ class PlayerMonitor {
      * @returns {HTMLElement|null} - The video element if found, otherwise null.
      */
     getPlayer() {
-        return document.querySelector(".video-ref.Layout-sc-1xcs6mc-0 > video");
+        return document.querySelector(".video-render-surface > video");
     }
 
     /**

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "TTV Ad Mute",
-  "version": "1.7",
+  "version": "1.8",
   "description": "Automatically mutes Twitch tabs when video ads start playing and unmutes the tab when the video ads stop.",
   "author": "Darrin Johnson",
   "homepage_url": "https://github.com/drj101687/ttv-ad-mute",
@@ -24,7 +24,6 @@
     }
   ],
   "background": {
-    "service_worker": "js/background.js",
     "scripts": ["js/background.js"]
   },
   "icons": {


### PR DESCRIPTION
…release. Changed video CSS selector to be more consistent. update version to v1.8

`"service_worker": "js/background.js",` was causing issues when the addon is installed via marketplace. This didn't cause issues when loading the extension locally for testing. Going to remove it until the repo has a build to support generating/packaging different manifest for different platforms.

Also re-targeting the video with an updated CSS selector to be more consistent. 